### PR TITLE
Documentation updates and naming conventions in configurator

### DIFF
--- a/Configurator.cs
+++ b/Configurator.cs
@@ -10,18 +10,18 @@ namespace StockportGovUK.AspNetCore.Logging.Elasticsearch.Aws
 {
     public class Configurator
     {
-        private static string defaultLogConfigurationKeyName = "ElasticSearchAwsConfiguration";
-        private static string defaultLogConfigurationSecretsKeyName = "ElasticSearchAwsSecretsConfiguration";
+        private static string defaultLogConfigurationKey = "ElasticSearchAwsConfiguration";
+        private static string defaultLogConfigurationSecretsKey = "ElasticSearchAwsSecretsConfiguration";
 
         public static void Configure(IConfiguration appConfiguration, LoggerConfiguration loggerConfiguration)
         {
-            Configure(appConfiguration, loggerConfiguration, defaultLogConfigurationKeyName, defaultLogConfigurationSecretsKeyName);
+            Configure(appConfiguration, loggerConfiguration, defaultLogConfigurationKey, defaultLogConfigurationSecretsKey);
         }
 
-        public static void Configure(IConfiguration appConfiguration, LoggerConfiguration loggerConfiguration, string logConfigurationKeyName, string logSecretConfigurationKeyName)
+        public static void Configure(IConfiguration appConfiguration, LoggerConfiguration loggerConfiguration, string logConfigurationKey, string logSecretConfigurationKey)
         {
-            var logConfigurationSection = appConfiguration.GetSection(logConfigurationKeyName);
-            var logSecretConfigurationSection = appConfiguration.GetSection(logSecretConfigurationKeyName);
+            var logConfigurationSection = appConfiguration.GetSection(logConfigurationKey);
+            var logSecretConfigurationSection = appConfiguration.GetSection(logSecretConfigurationKey);
             var logConfiguration = new LogConfiguration();
             var logSecretConfiguration = new LogSecretConfiguration();
         

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # StockportGovUK.AspNetCore.Logging.Elasticsearch.Aws
-A package that wraps setup and configuration of Serilog and log to Elasticsearch running in AWS
+This package wraps the setup and configuration of Serilog for logging to Elasticsearch running in AWS. It enables specification in configuration file by convention.
+
+The default convention for configuration files is as below:
+```json
+"ElasticSearchAwsConfiguration": {
+    "Region": "[AWS Region]<string>",
+    "IndexFormat": "[Index Format]<string>",
+    "InlineFields": false,
+    "MinimumLevel": "[Minimum Warning Level]<string>",
+    "Enabled": false,
+    "Url": "[Elasticsearch URL]<string>"
+}
+"ElasticSearchAwsSecretsConfiguration": {
+    "AccessKey": "[AWS Access Key]<string>",
+    "SecretKey": "[AWS Secret Key]<string>"
+}
+```
+
+Enable configuration in Startup as per example below:
+```C#
+public void ConfigureServices(IServiceCollection services)
+{
+    // Your logger config here eg.
+    var loggerConfiguration = new LoggerConfiguration()
+        .ReadFrom
+        .Configuration(Configuration)
+
+    Configurator.Configure(Configuration, loggerConfiguration);
+
+    Log.Logger = loggerConfiguration.CreateLogger();
+}
+```


### PR DESCRIPTION
Naming conventions change to "Key" rather than "KeyName" for variable naming, Example docs added to readme.